### PR TITLE
rv_get_keycode: Add KEY_FN support

### DIFF
--- a/src/evdev.c
+++ b/src/evdev.c
@@ -127,6 +127,7 @@ int rv_init_evdev() {
 }
 
 int rv_get_keycode(char *ev_keyname) {
+	if (strncmp("KEY_FN", ev_keyname, 7) == 0) return 76;
 	int ev_code = libevdev_event_code_from_name(EV_KEY, ev_keyname);
 	if (ev_code < 0 || ev_code > 254) return -1;
 	return (rv_ev2rv[ev_code] == 0xff) ? -1 : rv_ev2rv[ev_code];


### PR DESCRIPTION
Allows setting a static color to the FN key, which does not seem to have an evdev key name for our keyboard.