### PR TITLE
Add mode to read from named pipe to set static colors

### DIFF
--- a/src/roccat-vulcan.h
+++ b/src/roccat-vulcan.h
@@ -87,5 +87,6 @@ void rv_fx_topo_rows();
 void rv_fx_topo_cols();
 void rv_fx_topo_keys();
 void rv_fx_topo_neigh();
+void rv_fx_piped(char *pipe_name);
 
 #endif


### PR DESCRIPTION
Allow external programs to control colors and create own effects by
writing to the given named pipe.

Usage e.g.
mkfifo mypipe
roccat-vulcan -p mypipe &
echo -e "rgb:all:0,255,0\nrgb:KEY_W:0,255,255\nrgb:KEY_A:0,255,255\nrgb:KEY_S:0,255,255\nrgb:KEY_D:0,255,255" > mypipe


It has been some time since I wrote this, but haven't PR'ed it before since I wanted to add more like e.g. controlling key brightness.
Unfortunately I haven't really found the time to do anything related recently, but I'm already happy with the current functionality - additional features can still be added in the future.

I'm creating this PR now since it might still be useful for others, e.g. it can be used for static colors as requested in issue #12.
Personally, I have some scripts set up to toggle between several static color-setups and also use key colors to indicate more information like shift status, numlock, and media playback.